### PR TITLE
feat: enhance dashboard stats

### DIFF
--- a/lib/api/dashboardHandler.js
+++ b/lib/api/dashboardHandler.js
@@ -53,12 +53,35 @@ export default async function dashboardHandler(req, res) {
       .sort((a, b) => (b.count - a.count) || a.tag.localeCompare(b.tag))
       .slice(0, 20);
 
+    // Enrichment status
+    const enriched = products.filter((p) => {
+      const hasDescription = typeof p?.description === 'string' && p.description.trim() !== '';
+      const hasTags = Array.isArray(p?.tags) && p.tags.length > 0;
+      const hasPrice = typeof p?.price === 'number';
+      return hasDescription && hasTags && hasPrice;
+    }).length;
+
+    // Recent activity (fallback to id ordering when no timestamps)
+    const recentProducts = products
+      .slice()
+      .sort((a, b) => {
+        const ta = new Date(a.updatedAt || 0).getTime();
+        const tb = new Date(b.updatedAt || 0).getTime();
+        if (tb === ta) return (b.id || 0) - (a.id || 0);
+        return tb - ta;
+      })
+      .slice(0, 5)
+      .map((p) => ({ id: p.id, name: p.name, updatedAt: p.updatedAt || null }));
+
     res.status(200).json({
       totalProducts,
       inStock,
       outOfStock: Math.max(0, totalProducts - inStock),
       totalTags: Object.keys(tagCounts).length,
       topTags,
+      enriched,
+      notEnriched: Math.max(0, totalProducts - enriched),
+      recentProducts,
       generatedAt: new Date().toISOString(),
     });
   } catch (e) {

--- a/pages/admin/dashboard.js
+++ b/pages/admin/dashboard.js
@@ -44,6 +44,14 @@ export default function AdminDashboard() {
               <div style={{ fontSize: 12, color: '#666' }}>Unique tags</div>
               <div style={{ fontSize: 24, fontWeight: 600 }}>{stats.totalTags}</div>
             </div>
+            <div style={{ border: '1px solid #eee', borderRadius: 8, padding: '0.75rem' }}>
+              <div style={{ fontSize: 12, color: '#666' }}>Enriched</div>
+              <div style={{ fontSize: 24, fontWeight: 600, color: '#128a0c' }}>{stats.enriched}</div>
+            </div>
+            <div style={{ border: '1px solid #eee', borderRadius: 8, padding: '0.75rem' }}>
+              <div style={{ fontSize: 12, color: '#666' }}>Needs enrichment</div>
+              <div style={{ fontSize: 24, fontWeight: 600, color: '#b00020' }}>{stats.notEnriched}</div>
+            </div>
           </section>
 
           {stats.topTags && stats.topTags.length > 0 && (
@@ -57,6 +65,19 @@ export default function AdminDashboard() {
                 ))}
               </div>
               <div style={{ color: '#888', marginTop: '0.5rem', fontSize: 12 }}>Updated {new Date(stats.generatedAt).toLocaleString()}</div>
+            </section>
+          )}
+
+          {stats.recentProducts && stats.recentProducts.length > 0 && (
+            <section style={{ marginTop: '1rem' }}>
+              <h2 style={{ fontSize: 16, margin: '0.5rem 0' }}>Recent products</h2>
+              <ul style={{ paddingLeft: '1.2rem' }}>
+                {stats.recentProducts.map((p) => (
+                  <li key={p.id} style={{ marginBottom: '0.25rem' }}>
+                    {p.name || `Product ${p.id}`}
+                  </li>
+                ))}
+              </ul>
             </section>
           )}
         </div>

--- a/tests/api-dashboard.test.js
+++ b/tests/api-dashboard.test.js
@@ -48,6 +48,9 @@ describe('API /api/dashboard', () => {
     expect(typeof data.inStock).toBe('number');
     expect(typeof data.outOfStock).toBe('number');
     expect(Array.isArray(data.topTags)).toBe(true);
+    expect(typeof data.enriched).toBe('number');
+    expect(typeof data.notEnriched).toBe('number');
+    expect(Array.isArray(data.recentProducts)).toBe(true);
   });
 
   test('totalProducts matches product catalog size', async () => {
@@ -60,5 +63,6 @@ describe('API /api/dashboard', () => {
     const products = await resolveProducts();
     expect(data.totalProducts).toBe(products.length);
     expect(data.inStock + data.outOfStock).toBe(products.length);
+    expect(data.enriched + data.notEnriched).toBe(products.length);
   });
 });


### PR DESCRIPTION
## Summary
- extend dashboard API with enrichment counts and recent product activity
- surface enriched status and recent products in admin dashboard
- cover new fields with API test assertions

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689915f9fcf8832aa0afeac9c350272e