### PR TITLE
fix: add keepalive API route

### DIFF
--- a/pages/api/keepalive.js
+++ b/pages/api/keepalive.js
@@ -1,0 +1,3 @@
+export default function handler(req, res) {
+  res.status(200).json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- add keepalive API endpoint that returns `{ ok: true }`

## Testing
- `npm test` *(fails: Jest worker encountered child process exceptions)*
- `NODE_OPTIONS=--openssl-legacy-provider npx next build`


------
https://chatgpt.com/codex/tasks/task_e_689b12a8575c832a95579099e8936df4