### PR TITLE
Fix missing export in attributes API route

### DIFF
--- a/pages/api/attributes/index.js
+++ b/pages/api/attributes/index.js
@@ -58,5 +58,4 @@ async function handler(req, res) {
   res.status(405).json({ error: 'Method Not Allowed' });
 }
 
-module.exports = handler;
-module.exports.default = handler;
+export default handler;


### PR DESCRIPTION
## Summary
- ensure attributes API handler is exported with closing brace and export statement

## Testing
- `npx next build` *(fails: Error: error:0308010C:digital envelope routines::unsupported)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b12d05ea4832ab012393fbf7331ef