### PR TITLE
feat: add global dashboard header

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,77 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+const navItems = [
+  { href: '/', label: 'Products' },
+  { href: '/attributes', label: 'Attributes' },
+  { href: '/attribute-groups', label: 'Attribute Groups' },
+  { href: '/tags', label: 'Tags' },
+  { href: '/tools', label: 'Tools' },
+  { href: '/admin', label: 'Admin' }
+];
+
+export default function Header() {
+  const router = useRouter();
+
+  return (
+    <header style={headerStyle}>
+      <nav style={navStyle} aria-label="Main">
+        <div style={brandStyle}>Simple PIM</div>
+        <div style={linksWrapperStyle}>
+          {navItems.map((item) => {
+            const active = router.pathname === item.href || router.pathname.startsWith(item.href + '/');
+            return (
+              <Link key={item.href} href={item.href} passHref>
+                <a
+                  style={{
+                    ...linkStyle,
+                    ...(active ? activeLinkStyle : null)
+                  }}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  {item.label}
+                </a>
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+    </header>
+  );
+}
+
+const headerStyle = {
+  background: '#1f2937',
+  color: '#fff'
+};
+
+const navStyle = {
+  maxWidth: 1200,
+  margin: '0 auto',
+  padding: '0.5rem 1rem',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1rem'
+};
+
+const brandStyle = {
+  fontWeight: 600
+};
+
+const linksWrapperStyle = {
+  display: 'flex',
+  gap: '0.5rem',
+  flexWrap: 'wrap'
+};
+
+const linkStyle = {
+  padding: '0.25rem 0.5rem',
+  borderRadius: 4,
+  textDecoration: 'none',
+  color: '#d1d5db'
+};
+
+const activeLinkStyle = {
+  color: '#fff',
+  background: '#111827'
+};

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,1 +1,10 @@
-const Layout = ({ children }) => <div>{children}</div>; export default Layout;
+import Header from './Header';
+
+const Layout = ({ children }) => (
+  <div>
+    <Header />
+    {children}
+  </div>
+);
+
+export default Layout;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,10 @@
+import Layout from '../components/Layout';
+import '../styles.css';
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
+}

--- a/pages/admin/bulk-tags.js
+++ b/pages/admin/bulk-tags.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import Layout from '../../components/Layout';
 
 export default function BulkTagsAdminPage() {
   const [skuText, setSkuText] = React.useState('');
@@ -35,9 +34,8 @@ export default function BulkTagsAdminPage() {
   }
 
   return (
-    <Layout title="Bulk Tagging Preview">
-      <div style={container}>
-        <h1>Bulk Tagging Preview</h1>
+    <div style={container}>
+      <h1>Bulk Tagging Preview</h1>
         <p>Paste SKUs and specify tags to add or remove. This tool previews changes and does not persist updates.</p>
 
         <form onSubmit={onPreview} style={form}>
@@ -85,8 +83,8 @@ export default function BulkTagsAdminPage() {
           <div style={{ marginTop: 24 }}>
             <h2>Result</h2>
             <div style={{ color: '#374151' }}>
-              Matched: <strong>{result.stats.matched}</strong>, Updated: <strong>{result.stats.updated}</strong>,
-              Added tags: <strong>{result.stats.added}</strong>, Removed tags: <strong>{result.stats.removed}</strong>
+              Matched: <strong>{result.stats.matched}</strong>, Updated: <strong>{result.stats.updated}</strong>, Added tags:{' '}
+              <strong>{result.stats.added}</strong>, Removed tags: <strong>{result.stats.removed}</strong>
             </div>
             <table style={table}>
               <thead>
@@ -101,7 +99,9 @@ export default function BulkTagsAdminPage() {
               <tbody>
                 {result.items.map((it) => (
                   <tr key={it.sku}>
-                    <td style={td}><code>{it.sku}</code></td>
+                    <td style={td}>
+                      <code>{it.sku}</code>
+                    </td>
                     <td style={td}>{Array.isArray(it.before) ? it.before.join(', ') : ''}</td>
                     <td style={td}>{Array.isArray(it.after) ? it.after.join(', ') : ''}</td>
                     <td style={td}>{Array.isArray(it.added) ? it.added.join(', ') : ''}</td>
@@ -113,7 +113,6 @@ export default function BulkTagsAdminPage() {
           </div>
         ) : null}
       </div>
-    </Layout>
   );
 }
 

--- a/pages/admin/tags-stats.js
+++ b/pages/admin/tags-stats.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Layout from '../../components/Layout';
 
 const TagsStatsPage = () => {
   const [data, setData] = useState({ counts: {}, top: [] });
@@ -30,26 +29,27 @@ const TagsStatsPage = () => {
   }, []);
 
   return (
-    <Layout>
-      <div style={{ maxWidth: 900, margin: '0 auto', padding: '1rem' }}>
-        <h1 style={{ marginBottom: '0.5rem' }}>Tag Stats</h1>
-        <p style={{ color: '#666', marginTop: 0 }}>
-          Unique tags: {Object.keys(data.counts || {}).length}
-        </p>
-        {loading && <div>Loading…</div>}
-        {error && <div role="alert" style={{ color: 'crimson' }}>{error}</div>}
-        {!loading && !error && (
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '0.5rem' }}>
-            {(data.top || []).map((t) => (
-              <div key={t.tag} style={{ border: '1px solid #eee', borderRadius: 8, padding: '0.5rem 0.75rem', background: '#fafafa' }}>
-                <div style={{ fontWeight: 600 }}>{t.tag}</div>
-                <div style={{ color: '#555', fontSize: 12 }}>{t.count} product{t.count === 1 ? '' : 's'}</div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </Layout>
+    <div style={{ maxWidth: 900, margin: '0 auto', padding: '1rem' }}>
+      <h1 style={{ marginBottom: '0.5rem' }}>Tag Stats</h1>
+      <p style={{ color: '#666', marginTop: 0 }}>
+        Unique tags: {Object.keys(data.counts || {}).length}
+      </p>
+      {loading && <div>Loading…</div>}
+      {error && <div role="alert" style={{ color: 'crimson' }}>{error}</div>}
+      {!loading && !error && (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '0.5rem' }}>
+          {(data.top || []).map((t) => (
+            <div
+              key={t.tag}
+              style={{ border: '1px solid #eee', borderRadius: 8, padding: '0.5rem 0.75rem', background: '#fafafa' }}
+            >
+              <div style={{ fontWeight: 600 }}>{t.tag}</div>
+              <div style={{ color: '#555', fontSize: 12 }}>{t.count} product{t.count === 1 ? '' : 's'}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,10 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  background: #f9fafb;
+  color: #111827;
+}
+
+a {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- add header component with navigation to core PIM sections
- wrap all pages with layout and global styles
- drop redundant layout wrappers in admin pages

## Testing
- `npm test` *(fails: Jest worker encountered 4 child process exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_689b267ac4e8832a91aeff9e4fd73a88