### PR TITLE
Validate repository parameters in safeTreeCommit

### DIFF
--- a/src/lib/safeTreeCommit.ts
+++ b/src/lib/safeTreeCommit.ts
@@ -1,5 +1,3 @@
-import { Octokit } from "octokit";
-
 export async function safeTreeCommit({
   token,
   owner,
@@ -19,6 +17,10 @@ export async function safeTreeCommit({
   encoding?: "utf-8" | "base64";
   force?: boolean;
 }) {
+  if (!owner?.trim() || !repo?.trim()) {
+    throw new Error("Both `owner` and `repo` must be provided separately.");
+  }
+  const { Octokit } = await import("octokit");
   const octokit = new Octokit({ auth: token });
 
   // 1) Resolve branch head → commit SHA

--- a/tests/safeTreeCommit.test.ts
+++ b/tests/safeTreeCommit.test.ts
@@ -1,0 +1,16 @@
+import { strict as assert } from 'node:assert';
+import { safeTreeCommit } from '../src/lib/safeTreeCommit';
+
+async function run() {
+  await assert.rejects(
+    safeTreeCommit({ token: 't', owner: '', repo: 'r', files: [] }),
+    /owner.*repo.*provided/
+  );
+  await assert.rejects(
+    safeTreeCommit({ token: 't', owner: 'o', repo: '', files: [] }),
+    /owner.*repo.*provided/
+  );
+  console.log('safeTreeCommit parameter validation tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- ensure `owner` and `repo` are provided before creating commits
- add tests covering missing repository parameters

## Testing
- `npx tsx tests/safeTreeCommit.test.ts`
- `PYTHONPATH=. pytest` *(fails: tests/test_greet.py::test_greet_default, tests/test_hello.py::test_greet_default)*

------
https://chatgpt.com/codex/tasks/task_e_68bb03868ad4832a830534786a180e29